### PR TITLE
PointList: reverse-geocoded place names

### DIFF
--- a/frontend/src/components/PlannerPanel/PointList.tsx
+++ b/frontend/src/components/PlannerPanel/PointList.tsx
@@ -1,6 +1,7 @@
 "use client";
 import type { RoutePlanDispatch } from "../../hooks/useRoutePlan";
-import type { RoutePlan } from "../../types/route.types";
+import { usePlaceNames, placeNameKey } from "../../hooks/usePlaceNames";
+import type { RoutePlan, LngLat } from "../../types/route.types";
 
 interface PointListProps {
   plan: RoutePlan;
@@ -10,15 +11,35 @@ interface PointListProps {
 const formatCoord = ([lng, lat]: [number, number]) =>
   `${lat.toFixed(4)}, ${lng.toFixed(4)}`;
 
+const formatTitle = (full: string, [lng, lat]: LngLat) =>
+  `${full}\n(${lat.toFixed(5)}, ${lng.toFixed(5)})`;
+
 const PointList = ({ plan, dispatch }: PointListProps) => {
   const hasEnd = plan.mode === "p2p" && !!plan.end;
+
+  const allPoints: LngLat[] = [
+    ...(plan.start ? [plan.start] : []),
+    ...plan.waypoints,
+    ...(hasEnd && plan.end ? [plan.end] : []),
+  ];
+  const placeNames = usePlaceNames(allPoints);
+
+  const labelFor = (point: LngLat, prefix?: string) => {
+    const place = placeNames[placeNameKey(point)];
+    const fallback = prefix ? `${prefix} · ${formatCoord(point)}` : formatCoord(point);
+    const text = place ? place.short : fallback;
+    const title = formatTitle(place ? place.full : fallback, point);
+    return { text, title };
+  };
 
   return (
     <ul className="flex flex-col gap-1 text-sm">
       {plan.start && (
         <li className="flex items-center gap-2 bg-gray-50 rounded px-2 py-1">
           <span className="inline-block w-2.5 h-2.5 rounded-full bg-green-500" />
-          <span className="flex-1">Start · {formatCoord(plan.start)}</span>
+          <span className="flex-1 truncate" title={labelFor(plan.start, "Start").title}>
+            {labelFor(plan.start, "Start").text}
+          </span>
           <button
             onClick={() => dispatch({ type: "removePoint", index: 0 })}
             className="text-red-500 hover:text-red-700"
@@ -34,7 +55,9 @@ const PointList = ({ plan, dispatch }: PointListProps) => {
           <span className="inline-flex items-center justify-center w-4 h-4 text-[10px] rounded-full bg-blue-500 text-white">
             {i + 1}
           </span>
-          <span className="flex-1">{formatCoord(wp)}</span>
+          <span className="flex-1 truncate" title={labelFor(wp).title}>
+            {labelFor(wp).text}
+          </span>
           <button
             onClick={() =>
               dispatch({ type: "reorderWaypoint", from: i, to: i - 1 })
@@ -68,7 +91,9 @@ const PointList = ({ plan, dispatch }: PointListProps) => {
       {hasEnd && plan.end && (
         <li className="flex items-center gap-2 bg-gray-50 rounded px-2 py-1">
           <span className="inline-block w-2.5 h-2.5 rounded-full bg-red-500" />
-          <span className="flex-1">End · {formatCoord(plan.end)}</span>
+          <span className="flex-1 truncate" title={labelFor(plan.end, "End").title}>
+            {labelFor(plan.end, "End").text}
+          </span>
           <button
             onClick={() =>
               dispatch({

--- a/frontend/src/hooks/usePlaceNames.ts
+++ b/frontend/src/hooks/usePlaceNames.ts
@@ -1,0 +1,112 @@
+"use client";
+import { useEffect, useState } from "react";
+import type { LngLat } from "../types/route.types";
+
+export type PlaceName = { short: string; full: string };
+
+export const placeNameKey = ([lng, lat]: LngLat) =>
+  `${lng.toFixed(5)},${lat.toFixed(5)}`;
+
+const keyFor = placeNameKey;
+
+// Module-level cache shared across all hook instances/renders so a point is
+// NEVER geocoded twice, even across reorders/drag-releases that recreate
+// component state. `null` marks a resolved-but-empty/failed lookup so we
+// don't retry it.
+const cache = new Map<string, PlaceName | null>();
+// In-flight request dedupe, keyed the same way.
+const pending = new Map<string, Promise<void>>();
+
+interface GeocodeContextItem {
+  id?: string;
+  text?: string;
+}
+
+interface GeocodeFeature {
+  text?: string;
+  place_name?: string;
+  context?: GeocodeContextItem[];
+}
+
+interface GeocodeResponse {
+  features?: GeocodeFeature[];
+}
+
+async function fetchPlaceName(point: LngLat, key: string): Promise<void> {
+  const token = process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN;
+  if (!token) {
+    cache.set(key, null);
+    return;
+  }
+
+  const [lng, lat] = point;
+  const url = `https://api.mapbox.com/geocoding/v5/mapbox.places/${lng},${lat}.json?access_token=${token}&types=poi,address,neighborhood,locality&limit=1`;
+
+  try {
+    const res = await fetch(url);
+    if (!res.ok) {
+      cache.set(key, null);
+      return;
+    }
+    const data: GeocodeResponse = await res.json();
+    const feature = data.features?.[0];
+    if (!feature || !feature.text) {
+      cache.set(key, null);
+      return;
+    }
+
+    const locality = feature.context?.find(
+      (c) => typeof c.id === "string" && /^(neighborhood|locality|place)\./.test(c.id)
+    )?.text;
+
+    const short = locality ? `${feature.text}, ${locality}` : feature.text;
+    const full = feature.place_name ?? short;
+
+    cache.set(key, { short, full });
+  } catch {
+    // Network error, offline, CORS, etc. — fall back to coordinates, never throw.
+    cache.set(key, null);
+  }
+}
+
+/**
+ * Reverse-geocodes a list of points via Mapbox and returns a map of
+ * `${lng.toFixed(5)},${lat.toFixed(5)}` -> PlaceName. Results are cached at
+ * module scope so a given point is only ever geocoded once, regardless of
+ * how many times it's passed back in (reorders, drag releases, remounts).
+ */
+export function usePlaceNames(
+  points: LngLat[]
+): Record<string, PlaceName | undefined> {
+  const [, forceRender] = useState(0);
+
+  const keys = points.map(keyFor);
+  const keysSignature = keys.join("|");
+
+  useEffect(() => {
+    let cancelled = false;
+
+    points.forEach((point) => {
+      const key = keyFor(point);
+      if (cache.has(key) || pending.has(key)) return;
+
+      const promise = fetchPlaceName(point, key).finally(() => {
+        pending.delete(key);
+        if (!cancelled) forceRender((n) => n + 1);
+      });
+      pending.set(key, promise);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [keysSignature]);
+
+  const result: Record<string, PlaceName | undefined> = {};
+  keys.forEach((key) => {
+    const entry = cache.get(key);
+    result[key] = entry ?? undefined;
+  });
+  return result;
+}


### PR DESCRIPTION
## Summary

- PointList rows now show human-readable place names (e.g. "Church St, Newtown") instead of raw coordinates, resolved via Mapbox Geocoding v5 reverse geocoding (`types=poi,address,neighborhood,locality&limit=1`).
- New hook `frontend/src/hooks/usePlaceNames.ts`: `usePlaceNames(points: LngLat[]) -> Record<string, PlaceName | undefined>`, keyed by `${lng.toFixed(5)},${lat.toFixed(5)}`.
- Start dot / numbered waypoints / end marker and all existing buttons (remove, reorder) are unchanged.

## Caching / no-refetch guarantee

- A module-level `Map<string, PlaceName | null>` cache lives outside the hook, keyed the same way as the lookup. Once a point resolves (success or failure), it is never geocoded again — reordering waypoints, dragging a marker and releasing it back onto an already-seen coordinate, or remounting PointList all read from the cache instead of hitting the network.
- A separate `pending` map dedupes in-flight requests so two components (or a fast reorder) requesting the same point simultaneously only fire one fetch.
- Failures (missing `NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN`, network/offline error, non-OK response, empty `features`) are cached as `null` — permanently, no retry loop — and the row falls back to formatted coordinates.

## Fallback behavior

- With no Mapbox token (e.g. `.env.example` default) or while offline, every point resolves to `null` in the cache and PointList renders `"Start · -33.91050, 151.19200"`-style coordinates exactly as before, never throwing.
- While a lookup is in flight, the row also shows coordinates, then swaps to the place name once resolved (each row re-renders independently via the hook's internal `forceRender`).

## Hover detail

- `title` attribute on each row = `${full}\n(${lat}, ${lng})` (5 decimal places) using the full Mapbox `place_name`, so the native browser tooltip carries the complete address/coordinates regardless of whether the short name or the coordinate fallback is shown.
- Row text uses `truncate` so long names ellipsis instead of wrapping.

## Verification

- `npm ci`, `npm run lint`, `npm run build` all clean in `frontend/` (pre-existing `useMapbox.ts` exhaustive-deps warning is unrelated to this change).
- No new dependencies added; no changes to markers, map, reducer, api, or backend code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)