### PR TITLE
Fix CI vitest invocation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm run build
-      - run: npx vitest run --if-present
+      - run: npm test
       - run: npx playwright install --with-deps chromium
       - run: npx playwright test
         env:


### PR DESCRIPTION
`npx vitest run --if-present` fails: --if-present is an npm flag, unknown to vitest. Use `npm test` (script exists since M4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)